### PR TITLE
remove `export `, as that breaks on newer versions of docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-export ST2_VERSION=3.2.0
-export ST2_PACKS_DEV="../../snpseq_packs"
+ST2_VERSION=3.2.0
+ST2_PACKS_DEV="../../snpseq_packs"


### PR DESCRIPTION
As per this [bug report at the docker-compose repo](https://github.com/docker/compose/issues/6838) the export statement causes problems with (I guess) docker-compose version 1.25 and later.

> Anything in the .env file will be loaded and exposed within the environment when you run docker-compose. There's never been a need to export those vars.
> 
> With that said, it's often convenient to export variables here for other things. [...]

(https://github.com/docker/compose/issues/6838#issuecomment-524908500)