### PR TITLE
Fix apt-get update issue in st2actionrunner container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,6 @@ services:
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
       - stackstorm-keys:/etc/st2/keys:ro
-    dns_search: .
     extra_hosts:
       - "host.docker.internal:host-gateway"
   st2garbagecollector:


### PR DESCRIPTION
This fixes an issue where `apt-get update` couldn't be run in the st2actionrunner, which is required for setting up the snpseq_packs development environment. 

Read more in: https://gitlab.snpseq.medsci.uu.se/shared/snpseq_packs/-/merge_requests/117