### PR TITLE
DEVELOP-1799 Disable rules

### DIFF
--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -26,3 +26,6 @@ ln -fs /opt/stackstorm/packs.dev/snpseq_packs.yaml /opt/stackstorm/configs/snpse
 
 ## Make sure config is loaded
 st2ctl reload --register-configs
+
+## Make sure rules are disabled
+/opt/stackstorm/packs/snpseq_packs/scripts/rule_switch disable


### PR DESCRIPTION
This MR adds a step to the startup scripts that disables all snpseq_packs rules. This is to avoid that rules are involuntarily triggered when replacing dummy values in the config. If the user wants to test a rule they have to enable it manually through the st2 CLI.

I have tested this version on my machine and could confirm that the rules were disabled after running: 
```
docker-compose up -d && ./scripts/snpseq/startup.sh
```