### PR TITLE
Pin cryptography version to 38.0.4

### DIFF
--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -17,7 +17,8 @@ st2 run packs.load packs=snpseq_packs register=all
 
 ## Make virtualenv for snpseq_packs
 st2 run packs.setup_virtualenv packs=snpseq_packs
-/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4 #Refer: https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769
+#Refer: https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769
+/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4 
 # Make dummy config file for snpseq_packs
 sh -c '/opt/stackstorm/virtualenvs/snpseq_packs/bin/python /opt/stackstorm/packs/snpseq_packs/scripts/generate_example_config_from_schema.py /opt/stackstorm/packs/snpseq_packs/config.schema.yaml > /opt/stackstorm/packs/snpseq_packs/snpseq_packs.yaml'
 

--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -17,7 +17,7 @@ st2 run packs.load packs=snpseq_packs register=all
 
 ## Make virtualenv for snpseq_packs
 st2 run packs.setup_virtualenv packs=snpseq_packs
-/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4
+/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4 #Refer: https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769
 # Make dummy config file for snpseq_packs
 sh -c '/opt/stackstorm/virtualenvs/snpseq_packs/bin/python /opt/stackstorm/packs/snpseq_packs/scripts/generate_example_config_from_schema.py /opt/stackstorm/packs/snpseq_packs/config.schema.yaml > /opt/stackstorm/packs/snpseq_packs/snpseq_packs.yaml'
 

--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -17,7 +17,7 @@ st2 run packs.load packs=snpseq_packs register=all
 
 ## Make virtualenv for snpseq_packs
 st2 run packs.setup_virtualenv packs=snpseq_packs
-
+/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4
 # Make dummy config file for snpseq_packs
 sh -c '/opt/stackstorm/virtualenvs/snpseq_packs/bin/python /opt/stackstorm/packs/snpseq_packs/scripts/generate_example_config_from_schema.py /opt/stackstorm/packs/snpseq_packs/config.schema.yaml > /opt/stackstorm/packs/snpseq_packs/snpseq_packs.yaml'
 


### PR DESCRIPTION
This merge request pins the version of cryptography installed by pip to 38.0.4. This solve issues caused by pyOpenSSL when running snpseq_packs.