### PR TITLE
Fix nginx config

### DIFF
--- a/files/nginx.snpseq-tester.conf
+++ b/files/nginx.snpseq-tester.conf
@@ -19,7 +19,7 @@ http {
         location /checkqc/qc {
             limit_except GET { deny all; }
             default_type application/json;
-            return 200 '{"exit_status":"0"}';
+            return 200 '{"exit_status": 0}';
         }
         location /verify/ {
             proxy_pass http://localhost:10400/;

--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -19,8 +19,6 @@ st2 run packs.load packs=snpseq_packs register=all
 st2 run packs.setup_virtualenv packs=snpseq_packs
 #Refer: https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769
 /opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4 
-# Make dummy config file for snpseq_packs
-sh -c '/opt/stackstorm/virtualenvs/snpseq_packs/bin/python /opt/stackstorm/packs/snpseq_packs/scripts/generate_example_config_from_schema.py /opt/stackstorm/packs/snpseq_packs/config.schema.yaml > /opt/stackstorm/packs/snpseq_packs/snpseq_packs.yaml'
 
 # Create symlink to dummy pack config
 ln -fs /opt/stackstorm/packs.dev/snpseq_packs.yaml /opt/stackstorm/configs/snpseq_packs.yaml


### PR DESCRIPTION
- run_checkqc expects an integer as return code, not a string
- To make testing more practical, we expect the config to be already present in the snpseq_packs folder.