### PR TITLE
Setup test data for metadata action

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,6 +122,7 @@ services:
       - ${ST2_PACKS_DEV:-./packs.dev}:/opt/stackstorm/packs.dev:rw
       - stackstorm-virtualenvs:/opt/stackstorm/virtualenvs:rw
       - stackstorm-ssh:/home/stanley/.ssh
+      - stackstorm-ssh:/root/.ssh
       # Action runner needs access to keys since action definitions (Jinja
       # templates) can reference secrets
       - stackstorm-keys:/etc/st2/keys:ro

--- a/files/Dockerfile.snpseq-tester
+++ b/files/Dockerfile.snpseq-tester
@@ -36,6 +36,8 @@ RUN mkdir -p /data/labdata
 RUN mkdir -p /data/scratch
 RUN mkdir -p /data/uppmax_project/incoming/staging/reports
 RUN mkdir -p /data/uppmax_project/incoming/staging/test_runfolder/seqreports
+RUN mkdir -p /data/uppmax_project/incoming/staging/test_runfolder/MD5
+COPY tests/test_data/runfolders/210415_A00001_0123_BXYZ321XY/MD5/checksums.md5 /data/uppmax_project/incoming/staging/test_runfolder/MD5
 RUN mkdir -p /data/snpseq-tester/runfolders/Arkiverade
 RUN mkdir -p /data/olink
 RUN mkdir -p /var/log/nginx/

--- a/files/nginx.snpseq-tester.conf
+++ b/files/nginx.snpseq-tester.conf
@@ -113,4 +113,13 @@ http {
         }
     }
 
+    # Slack
+    server {
+        listen 80;
+        access_log /var/log/nginx/snpseq_slackbot.log;
+        location ~ (.*) {
+            return 202;
+        }
+    }
+
 }

--- a/scripts/snpseq/st2actionrunner-snpseq.sh
+++ b/scripts/snpseq/st2actionrunner-snpseq.sh
@@ -4,7 +4,7 @@
 apt-get update && apt-get install -y gcc python
 
 ## Copy dummy genologics config to home of root user (required for some snpseq_packs actions)
-cp /opt/stackstorm/packs/snpseq_packs/utils/.genologicsrc /root/
+cp /opt/stackstorm/packs.dev/utils/.genologicsrc /root/
 
 # create the known_hosts file and add the snpseq-tester host key
 ssh-keyscan -t ecdsa snpseq-tester >> /home/stanley/.ssh/known_hosts


### PR DESCRIPTION
This PR adds a `checksum.md5` file to the test runfolder, which is necessary to generate the runfolder's metadata.

It also fixes a couple of bugs that were encountered along the way.