### PR TITLE
Add step to create the version.txt file needed by the workflows

### DIFF
--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -32,3 +32,9 @@ st2ctl reload --register-configs
 # create the known_hosts file and add the snpseq-tester host key
 ssh-keyscan -t ecdsa snpseq-tester >> /home/stanley/.ssh/known_hosts
 chown -R stanley:stanley /home/stanley/.ssh
+
+# Make git trust the repo
+git config --global --add safe.directory /opt/stackstorm/packs.dev
+
+# Create version file based on latest commit
+cd /opt/stackstorm/packs/snpseq_packs && git log -1 --pretty=format:"%H" > version.txt


### PR DESCRIPTION
This PR updates the st2client script so that a version file is created in the packs repo. This is needed by the snpseq_packs workflows. 

We discovered that this step was missing when @torigiffin set up her snpseq_packs dev environment for the first time. This file is included in the .gitignore list in snpseq_packs so it was not apparent that it was missing. Creation of this file was previously done in a Vagrant setup script (which we used before docker) and I think most developers already had a copy created by that old script or created the version file manually when they got the error. 

Anyho, now it should work from scratch!

Verification: 
Tested in snpseq_packs by
* Removing my existing version.txt file
* Running docker/up and docker/test_workflows