### PR TITLE
Update samplesheet_processing samplesheet to have demultiplexer name

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+**What problems does this PR solve?**
+Provide a short description or reference to the relevant issue, explaining what problems this PR solves.
+
+**How has the changes been tested?**
+In addition to automatic tests, has any manual testing been carried out?
+
+**Reasons for careful code review**
+If any of the boxes below are checked, extra careful code review should be inititated.
+
+  - [ ] This PR contains code that could remove data

--- a/files/Dockerfile.snpseq-tester
+++ b/files/Dockerfile.snpseq-tester
@@ -46,7 +46,7 @@ RUN touch /var/log/nginx/access.log
 RUN echo '*' > /etc/arteria/misc/summary.rsync
 RUN echo '*' > /etc/arteria/misc/hiseq.rsync
 RUN echo '*' > /etc/arteria/misc/olink_explore.rsync
-RUN bash -c 'find /data/snpseq-tester/runfolders -maxdepth 2 -name "*SampleSheet.csv" |while read f; do n=$(echo $(basename $(dirname $f)) |rev |cut -f1 -d_ |rev); n=${n:1}; cp $f /mnt/samplesheet_processning/${n}_samplesheet.csv; done'
+RUN bash -c 'find /data/snpseq-tester/runfolders -maxdepth 2 -name "*SampleSheet.csv" |while read f; do n=$(echo $(basename $(dirname $f)) |rev |cut -f1 -d_ |rev); n=${n:1}; cp $f /mnt/samplesheet_processning/bcl2fastq_${n}_samplesheet.csv; done'
 RUN bash -c 'find /data/snpseq-tester/runfolders -maxdepth 1 -type d -name "*A00001*" |while read d; do n=$(basename $d); touch /data/scratch/$n; touch /data/snpseq-tester/runfolders/${n}_archive; done'
 RUN cp /mnt/samplesheet_processning/*.csv /data/
 RUN ln -s /usr/bin/echo /usr/local/bin/projman_filler


### PR DESCRIPTION
**What problems does this PR solve?**
This version updates the samplesheet name in the snpseq-tester container to contain the demultiplexer name. 
This is because both bcl2fastq and bclconvert samplesheets will be generated and need to be differentiated.

**How has the changes been tested?**
Deleted old image and did docker/up a fresh and tested with the stackstorm test_workflows to ensure the correct mounted samplesheet is retrieved and informative message is given if the samplesheet with the demultiplexer name is not found.

**Reasons for careful code review**
If any of the boxes below are checked, extra careful code review should be inititated.

  - [ ] This PR contains code that could remove data