### PR TITLE
DATAOPS-1447: Stackstorm 3.9

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-export ST2_VERSION=3.8.0
+export ST2_VERSION=3.9.0
 export ST2_PACKS_DEV="../../snpseq_packs"
 export ST2_EXPOSE_HTTP=0.0.0.0:8081

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,6 @@
+**Description**
+
+**Risk analysis**
+
+**Validation procedure**
+

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Open `http://localhost/` in your browser. StackStorm Username/Password by defaul
 
 The image version, exposed ports, chatops, and "packs.dev" directory are configurable with environment variables.
 
-- **ST2_VERSION** this is the tag at the end of the docker image (ie: stackstorm/st2api:v3.3.0)
+- **ST2_VERSION** this is the tag at the end of the docker image (ie: stackstorm/st2api:v3.9.0)
 - **ST2_IMAGE_REPO** The image or path to the images. Default is "stackstorm/".  You may change this is using the Enterprise version or a private docker repository.
 - **ST2_EXPOSE_HTTP**  Port to expose st2web port 80 on.  Default is `127.0.0.1:80`, and you may want to do `0.0.0.0:80` to expose on all interfaces.
 - **ST2_PACKS_DEV** Directory to development packs, absolute or relative to docker-compose.yml. This allows you to develop packs locally. Default is `./packs.dev`. When making a number of packs, it is recommended to make a directory outside of st2-docker, with each subdirectory underneath that being an independent git repo.  Example: `ST2_PACKS_DEV=${HOME}/mypacks`, with `${HOME}/mypacks/st2-helloworld` being a git repo for the "helloworld" pack.

--- a/scripts/snpseq/st2client-snpseq.sh
+++ b/scripts/snpseq/st2client-snpseq.sh
@@ -17,8 +17,6 @@ st2 run packs.load packs=snpseq_packs register=all
 
 ## Make virtualenv for snpseq_packs
 st2 run packs.setup_virtualenv packs=snpseq_packs
-#Refer: https://levelup.gitconnected.com/fix-attributeerror-module-lib-has-no-attribute-openssl-521a35d83769
-/opt/stackstorm/virtualenvs/snpseq_packs/bin/pip install cryptography==38.0.4 
 
 # Create symlink to dummy pack config
 ln -fs /opt/stackstorm/packs.dev/snpseq_packs.yaml /opt/stackstorm/configs/snpseq_packs.yaml


### PR DESCRIPTION
**Description**
Changes introduced in this PR: 
- st2 updated to 3.9.0
- Remove pinning of cryptography (it was a py3.8 workaround)
- Added PR template

**Risk analysis**
This change will make the dev environment incompatible with mm-xart001 and Stackstorm 3.8. I think that is fine though. In case the verification of the new Stackstorm version runs into issues we can always update snpseq_packs to use a previous version of this repo.

**Validation procedure**
Tested together with changes in https://gitlab.snpseq.medsci.uu.se/shared/snpseq_packs/-/commits/DATAOPS-1447_stackstorm_3.9_and_arteria-staging . Unit tests and workflow tests pass. When this PR has been merged I will update the submodule reference in that branch. 